### PR TITLE
Golang 1.9.4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.9.4
 RUN apt-get update && \
     apt-get install -y xz-utils zip rsync
 RUN go get github.com/rancher/trash


### PR DESCRIPTION
I had to upgrade to golang 1.9.4 to specifically SSL CA certs verification when using a custom CA authority.

FATA[0007] Get https://rancher/v2-beta/projects/1a5: x509: certificate signed by unknown authority

I am using OSX and this was fixed in golang 1.9.x. For more information, see https://github.com/docker/for-mac/issues/2201.

Unfortunately, previous versions of golang wouldn't consider CA certs stored in the System keychain. They would only look into the System Roots one, which is not writable.